### PR TITLE
This allows the restored CLI tool to be used rather than requiring packet to be installed standalone

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -46,6 +46,7 @@ Target.create "Pack" (fun _ ->
 
     Paket.pack(fun p ->
         { p with
+            ToolType = ToolType.CreateCLIToolReference()
             BuildConfig = "Release"
             OutputPath = "bin"
             MinimumFromLockFile = true


### PR DESCRIPTION
Currently the build script is calling paket as a standalone tool rather than using the restored CLI tool, this fixes that.