### PR TITLE
ENH: alias asyncs as tasks for fable compiler

### DIFF
--- a/src/Plough.ControlFlow/Either.fs
+++ b/src/Plough.ControlFlow/Either.fs
@@ -1,6 +1,6 @@
 ﻿namespace Plough.ControlFlow
 
-#if FABLE_COMPILER
+#if !FABLE_COMPILER
 open System.Threading.Tasks
 open FSharp.Control.Tasks
 #endif
@@ -210,7 +210,7 @@ module Either =
 
     /// Converts a Result<Task<_>,_> to an Task<Result<_,_>>
     let sequenceTask (resAsync : Either<Task<'a>>) : Task<Either<'a>> =
-    #if FABLE_COMPILER
+    #if !FABLE_COMPILER
         task {
     #else
         async {

--- a/src/Plough.ControlFlow/Either.fs
+++ b/src/Plough.ControlFlow/Either.fs
@@ -1,7 +1,9 @@
 ﻿namespace Plough.ControlFlow
 
+#if FABLE_COMPILER
 open System.Threading.Tasks
 open FSharp.Control.Tasks
+#endif
 
 type FailureMessage =
     | Unknown of string
@@ -208,7 +210,11 @@ module Either =
 
     /// Converts a Result<Task<_>,_> to an Task<Result<_,_>>
     let sequenceTask (resAsync : Either<Task<'a>>) : Task<Either<'a>> =
+    #if FABLE_COMPILER
         task {
+    #else
+        async {
+    #endif
             match resAsync with
             | Ok promise ->
                 let! x = promise.Data

--- a/src/Plough.ControlFlow/Either.fs
+++ b/src/Plough.ControlFlow/Either.fs
@@ -208,6 +208,8 @@ module Either =
     let teeError (f : FailureMessage -> unit) (result : Either<'a>) : Either<'a> =
         teeErrorIf (fun _ -> true) f result
 
+    
+    
     /// Converts a Result<Task<_>,_> to an Task<Result<_,_>>
     let sequenceTask (resAsync : Either<Task<'a>>) : Task<Either<'a>> =
     #if !FABLE_COMPILER

--- a/src/Plough.ControlFlow/List.fs
+++ b/src/Plough.ControlFlow/List.fs
@@ -27,8 +27,11 @@ module List =
         let mutable state = Either.succeed []
         let mutable index = 0
         let xs = xs |> List.toArray
-
+        #if FABLE_COMPILER
         task {
+        #else
+        async {
+        #endif
             while state |> Either.isSuccess && index < xs.Length do
                 let! r = xs |> Array.item index |> f
                 index <- index + 1

--- a/src/Plough.ControlFlow/List.fs
+++ b/src/Plough.ControlFlow/List.fs
@@ -27,7 +27,7 @@ module List =
         let mutable state = Either.succeed []
         let mutable index = 0
         let xs = xs |> List.toArray
-        #if FABLE_COMPILER
+        #if !FABLE_COMPILER
         task {
         #else
         async {

--- a/src/Plough.ControlFlow/Plough.ControlFlow.fsproj
+++ b/src/Plough.ControlFlow/Plough.ControlFlow.fsproj
@@ -4,6 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Task.fs" />
+    <Compile Include="TaskOp.fs" />
     <Compile Include="Either.fs" />
     <Compile Include="EitherCE.fs" />
     <Compile Include="EitherOp.fs" />
@@ -12,8 +14,6 @@
     <Compile Include="EitherOption.fs" />
     <Compile Include="EitherOptionCE.fs" />
     <Compile Include="EitherOptionOp.fs" />
-    <Compile Include="Task.fs" />
-    <Compile Include="TaskOp.fs" />
     <Compile Include="TaskEither.fs" />
     <Compile Include="TaskEitherCE.fs" />
     <Compile Include="TaskEitherOp.fs" />

--- a/src/Plough.ControlFlow/Task.fs
+++ b/src/Plough.ControlFlow/Task.fs
@@ -4,13 +4,15 @@ open System.Threading.Tasks
 open FSharp.Control.Tasks.Affine
 
 #if FABLE_COMPILER
-    type Task<'T> = Async<'T>
-#else
     type Task<'T> = System.Threading.Tasks.Task<'T>
+#else
+    type Task<'T> = Async<'T>
+    type Ply<'T> = Async<'T>
 #endif
 
 [<RequireQualifiedAccess>]
 module Task =
+    #if FABLE_COMPILER
     let singleton value = value |> Task.FromResult
 
     let bind (f : 'a -> Task<'b>) (x : Task<'a>) =
@@ -18,17 +20,7 @@ module Task =
             let! x = x
             return! f x
         }
-
-    let apply f x =
-        bind (fun f' -> bind (fun x' -> singleton (f' x')) x) f
-
-    let map f x = x |> bind (f >> singleton)
-
-    let map2 f x y = (apply (apply (singleton f) x) y)
-
-    let map3 f x y z = apply (map2 f x y) z
-
-
+    
     /// Takes two tasks and returns a tuple of the pair
     let zip (a1 : Task<_>) (a2 : Task<_>) =
         task {
@@ -43,4 +35,41 @@ module Task =
             ()
         }
     
-    let ofUnit (t : Task) = task { return! t }
+    let ofUnit (t : Task) = task { return! t }    
+        
+    #else
+    
+    let singleton value = async { return value }
+    
+    let bind (f : 'a -> Task<'b>) (x : Task<'a>) =
+        async {
+            let! x = x
+            return! f x
+        }
+    
+    /// Takes two tasks and returns a tuple of the pair
+    let zip (a1 : Task<_>) (a2 : Task<_>) =
+        async {
+            let! r1 = a1
+            let! r2 = a2
+            return r1, r2
+        }
+
+    let ignore (x : Task<'a>) : Task<unit> =
+        async {
+            let! _ = x
+            ()
+        }
+    
+    #endif
+    
+    let apply f x =
+        bind (fun f' -> bind (fun x' -> singleton (f' x')) x) f
+
+    let map f x = x |> bind (f >> singleton)
+
+    let map2 f x y = (apply (apply (singleton f) x) y)
+
+    let map3 f x y z = apply (map2 f x y) z
+
+

--- a/src/Plough.ControlFlow/Task.fs
+++ b/src/Plough.ControlFlow/Task.fs
@@ -7,7 +7,6 @@ open FSharp.Control.Tasks.Affine
     type Task<'T> = System.Threading.Tasks.Task<'T>
 #else
     type Task<'T> = Async<'T>
-    type Ply<'T> = Async<'T>
 #endif
 
 [<RequireQualifiedAccess>]

--- a/src/Plough.ControlFlow/Task.fs
+++ b/src/Plough.ControlFlow/Task.fs
@@ -3,7 +3,7 @@ namespace Plough.ControlFlow
 open System.Threading.Tasks
 open FSharp.Control.Tasks.Affine
 
-#if FABLE_COMPILER
+#if !FABLE_COMPILER
     type Task<'T> = System.Threading.Tasks.Task<'T>
 #else
     type Task<'T> = Async<'T>
@@ -12,7 +12,7 @@ open FSharp.Control.Tasks.Affine
 
 [<RequireQualifiedAccess>]
 module Task =
-    #if FABLE_COMPILER
+    #if !FABLE_COMPILER
     let singleton value = value |> Task.FromResult
 
     let bind (f : 'a -> Task<'b>) (x : Task<'a>) =

--- a/src/Plough.ControlFlow/TaskEItherOptionCE.fs
+++ b/src/Plough.ControlFlow/TaskEItherOptionCE.fs
@@ -1,13 +1,16 @@
 namespace Plough.ControlFlow
 
+#if !FABLE_COMPILER
 open FSharp.Control.Tasks.Affine.Unsafe
 open FSharp.Control.Tasks.Affine
 open Ply
+#endif
 
 [<AutoOpen>]
 module TaskEitherOptionCE =
 
     type TaskEitherOptionBuilder() =
+        #if !FABLE_COMPILER
         member inline _.Return(value : 'a) : Ply<Either<'a option>> = uply.Return <| either.Return(Some value)
 
         member inline _.ReturnFrom(taskEither : TaskEither<'a option>) : Ply<Either<'a option>> =
@@ -35,5 +38,36 @@ module TaskEitherOptionCE =
         member inline _.Delay f = uply.Delay f
 
         member inline _.Run(f : unit -> Ply<'m>) = task.Run f
+        #else
+        
+        member inline _.Return(value : 'a) : Task<Either<'a option>> = async.Return <| either.Return(Some value)
+
+        member inline _.ReturnFrom(taskEither : TaskEither<'a option>) : Task<Either<'a option>> =
+            async.ReturnFrom taskEither
+
+        member inline _.Bind(taskEither : TaskEither<'a option>, binder : 'a -> Task<Either<'b option>>) : Task<Either<'b option>> =
+            let binder' r =
+                async {
+                    match r with
+                    | Ok { Data = (Some x); Warnings = w } ->
+                        match! binder x with
+                        | Ok { Data = y; Warnings = yw } -> return Ok { Data = y; Warnings = w @ yw }
+                        | Error x -> return Error x
+                    | Ok { Data = None; Warnings = w } -> return Ok { Data = None; Warnings = w }
+                    | Error x -> return Either.fail x
+                }
+
+            async.Bind(taskEither, binder')
+
+        member inline _.Combine(tro1, tro2) =
+            tro1
+            |> TaskEitherOption.bind (fun _ -> tro2)
+            |> async.ReturnFrom
+
+        member inline _.Delay f = async.Delay f
+
+        member inline _.Run(f : unit -> Task<'m>) = async.ReturnFrom (f())
+        
+        #endif
 
     let taskEitherOption = TaskEitherOptionBuilder()

--- a/src/Plough.ControlFlow/TaskEither.fs
+++ b/src/Plough.ControlFlow/TaskEither.fs
@@ -1,6 +1,6 @@
 ﻿namespace Plough.ControlFlow
 
-#if FABLE_COMPILER 
+#if !FABLE_COMPILER 
 open FSharp.Control.Tasks.Affine
 #endif
 
@@ -21,7 +21,7 @@ module TaskEither =
         Task.map (Either.map f) te
 
     let bind (f : 'a -> TaskEither<'b>) (te : TaskEither<'a>) : TaskEither<'b> =
-    #if FABLE_COMPILER
+    #if !FABLE_COMPILER
         task {
     #else
         async {
@@ -46,7 +46,7 @@ module TaskEither =
         |> Task.map Either.succeed
     
     let ofAsync (aAsync : Async<'a>) : TaskEither<'a> =
-    #if FABLE_COMPILER
+    #if !FABLE_COMPILER
         aAsync
         |> Async.Catch
         |> Async.StartAsTask

--- a/src/Plough.ControlFlow/TaskEitherCE.fs
+++ b/src/Plough.ControlFlow/TaskEitherCE.fs
@@ -101,7 +101,7 @@ module TaskEitherCE =
         /// </summary>
         member inline _.Source(task : Task<Either<'a>>) : Task<Either<'a>> = task
         
-        #if FABLE_COMPILER
+        #if !FABLE_COMPILER
         /// <summary>
         /// Method lets us transform data types into our internal representation.
         /// </summary>
@@ -131,7 +131,7 @@ module TaskEitherCEExtensions =
         member inline _.Source(choice : Choice<'a, FailureMessage>) : Task<Either<'a>> =
             choice |> Either.ofChoice id |> Task.singleton
 
-        #if FABLE_COMPILER
+        #if !FABLE_COMPILER
         /// <summary>
         /// Method lets us transform data types into our internal representation.
         /// </summary>
@@ -147,11 +147,11 @@ module TaskEitherCEExtensions =
         member inline _.Source(task : Task<'a>) : Task<Either<'a>> =
             task |> Task.map Either.succeed
 
-        #if FABLE_COMPILER
+        #if !FABLE_COMPILER
         /// <summary>
         /// Method lets us transform data types into our internal representation.
         /// </summary>
-        member inline _.Source(t : Task) : Task<Either<unit>> =
+        member inline _.Source(t : System.Threading.Tasks.Task) : Task<Either<unit>> =
             task { return! t } |> Task.map Either.succeed
         #endif
         

--- a/src/Plough.ControlFlow/TaskEitherCE.fs
+++ b/src/Plough.ControlFlow/TaskEitherCE.fs
@@ -1,7 +1,6 @@
 ﻿namespace Plough.ControlFlow
 
 open System
-open System.Threading.Tasks
 open FSharp.Control.Tasks.Affine.Unsafe
 open FSharp.Control.Tasks.Affine
 open Ply
@@ -101,12 +100,14 @@ module TaskEitherCE =
         /// See https://stackoverflow.com/questions/35286541/why-would-you-use-builder-source-in-a-custom-computation-expression-builder
         /// </summary>
         member inline _.Source(task : Task<Either<'a>>) : Task<Either<'a>> = task
-
+        
+        #if FABLE_COMPILER
         /// <summary>
         /// Method lets us transform data types into our internal representation.
         /// </summary>
         member inline _.Source(result : Async<Either<'a>>) : Task<Either<'a>> = result |> Async.StartAsTask
-
+        #endif
+        
     let taskEither = TaskEitherBuilder()
 
 // Having members as extensions gives them lower priority in
@@ -130,6 +131,7 @@ module TaskEitherCEExtensions =
         member inline _.Source(choice : Choice<'a, FailureMessage>) : Task<Either<'a>> =
             choice |> Either.ofChoice id |> Task.singleton
 
+        #if FABLE_COMPILER
         /// <summary>
         /// Method lets us transform data types into our internal representation.
         /// </summary>
@@ -137,6 +139,7 @@ module TaskEitherCEExtensions =
             asyncComputation
             |> Async.StartAsTask
             |> Task.map Either.succeed
+        #endif
 
         /// <summary>
         /// Method lets us transform data types into our internal representation.
@@ -144,8 +147,11 @@ module TaskEitherCEExtensions =
         member inline _.Source(task : Task<'a>) : Task<Either<'a>> =
             task |> Task.map Either.succeed
 
+        #if FABLE_COMPILER
         /// <summary>
         /// Method lets us transform data types into our internal representation.
         /// </summary>
         member inline _.Source(t : Task) : Task<Either<unit>> =
             task { return! t } |> Task.map Either.succeed
+        #endif
+        

--- a/src/Plough.ControlFlow/TaskEitherOption.fs
+++ b/src/Plough.ControlFlow/TaskEitherOption.fs
@@ -1,7 +1,5 @@
 namespace Plough.ControlFlow
 
-open FSharp.Control.Tasks.Affine
-
 [<RequireQualifiedAccess>]
 module TaskEitherOption =
     let map (f : 'a -> 'b) (tro : TaskEither<'a option>) : TaskEither<'b option> = TaskEither.map (Option.map f) tro
@@ -21,7 +19,7 @@ module TaskEitherOption =
         TaskEither.map3 (Option.map3 f) x y z
 
     let retn (value : 'a) : TaskEither<'a option> =
-        task { return Either.succeed (Some value) }
+        Either.succeed (Some value) |> Task.singleton
 
     let apply (f : TaskEither<('a -> 'b) option>) (x : TaskEither<'a option>) : TaskEither<'b option> =
         map2 (fun f x -> f x) f x

--- a/src/Plough.ControlFlow/TaskOption.fs
+++ b/src/Plough.ControlFlow/TaskOption.fs
@@ -1,7 +1,8 @@
 namespace Plough.ControlFlow
 
-open System.Threading.Tasks
+#if FABLE_COMPILER 
 open FSharp.Control.Tasks.Affine
+#endif
 
 [<RequireQualifiedAccess>]
 module TaskOption =
@@ -9,18 +10,22 @@ module TaskOption =
     let inline map f ar = Task.map (Option.map f) ar
 
     let bind f (ar : Task<_>) =
+        #if FABLE_COMPILER 
         task {
+        #else
+        async {
+        #endif
             let! opt = ar
 
             let t =
                 match opt with
                 | Some x -> f x
-                | None -> task { return None }
+                | None -> None |> Task.singleton
 
             return! t
         }
 
-    let retn x = task { return Some x }
+    let retn x = Some x |> Task.singleton
 
     let apply f x =
         bind (fun f' -> bind (fun x' -> retn (f' x')) x) f

--- a/src/Plough.ControlFlow/TaskOption.fs
+++ b/src/Plough.ControlFlow/TaskOption.fs
@@ -1,6 +1,6 @@
 namespace Plough.ControlFlow
 
-#if FABLE_COMPILER 
+#if !FABLE_COMPILER 
 open FSharp.Control.Tasks.Affine
 #endif
 
@@ -10,7 +10,7 @@ module TaskOption =
     let inline map f ar = Task.map (Option.map f) ar
 
     let bind f (ar : Task<_>) =
-        #if FABLE_COMPILER 
+        #if !FABLE_COMPILER 
         task {
         #else
         async {

--- a/src/Plough.ControlFlow/TaskOptionCE.fs
+++ b/src/Plough.ControlFlow/TaskOptionCE.fs
@@ -1,21 +1,22 @@
 namespace Plough.ControlFlow
 
 open System
+#if !FABLE_COMPILER
 open FSharp.Control.Tasks.Affine.Unsafe
 open FSharp.Control.Tasks.Affine
 open Ply
+#endif
 
 [<AutoOpen>]
 module TaskOptionCE =
     type TaskOptionBuilder() =
+        #if !FABLE_COMPILER
         member inline _.Return(value : 'T) : Ply<Option<_>> = uply.Return <| option.Return value
 
         member inline _.ReturnFrom(taskResult : Task<Option<_>>) : Ply<Option<_>> = uply.ReturnFrom taskResult
 
-        #if !FABLE_COMPILER
         member inline this.ReturnFrom(asyncResult : Async<Option<_>>) : Ply<Option<_>> =
             this.ReturnFrom(Async.StartAsTask asyncResult)
-        #endif
 
         member inline _.ReturnFrom(result : Option<_>) : Ply<Option<_>> = uply.Return result
 
@@ -29,10 +30,8 @@ module TaskOptionCE =
 
             uply.Bind(taskResult, binder')
 
-        #if !FABLE_COMPILER
         member inline this.Bind(asyncResult : Async<Option<_>>, binder : 'T -> Ply<Option<_>>) : Ply<Option<_>> =
             this.Bind(Async.StartAsTask asyncResult, binder)
-        #endif
 
         member inline this.Bind(result : Option<_>, binder : 'T -> Ply<Option<_>>) : Ply<Option<_>> =
             let result = result |> Task.singleton
@@ -88,5 +87,80 @@ module TaskOptionCE =
             }
 
         member inline _.Run(f : unit -> Ply<'m>) = task.Run f
+        
+        #else
+        
+        member inline _.Return(value : 'T) : Task<Option<_>> = async.Return <| option.Return value
+
+        member inline _.ReturnFrom(taskResult : Task<Option<_>>) : Task<Option<_>> = taskResult
+
+        member inline _.ReturnFrom(result : Option<_>) : Task<Option<_>> = async.Return result
+
+        member inline _.Zero() : Task<Option<_>> = async.Return <| option.Zero()
+
+        member inline _.Bind(taskResult : Task<Option<_>>, binder : 'T -> Task<Option<_>>) : Task<Option<_>> =
+            let binder' r =
+                match r with
+                | Some x -> binder x
+                | None -> async.Return None
+
+            async.Bind(taskResult, binder')
+
+        member inline this.Bind(result : Option<_>, binder : 'T -> Task<Option<_>>) : Task<Option<_>> =
+            let result = result |> Task.singleton
+            this.Bind(result, binder)
+
+        member inline _.Delay(generator : unit -> Task<Option<_>>) = async.Delay(generator)
+
+        member inline _.Combine(computation1 : Task<Option<'T>>, computation2 : unit -> Task<Option<'U>>)
+                                : Task<Option<'U>> =
+            async {
+                match! computation1 with
+                | None -> return None
+                | Some _ -> return! computation2 ()
+            }
+
+        member inline _.TryWith(computation : unit -> Task<Option<_>>, handler : exn -> Task<Option<_>>)
+                                : Task<Option<_>> =
+            async.TryWith(computation(), handler)
+
+        member inline _.TryFinally(computation : unit -> Task<Option<_>>, compensation : unit -> unit) : Task<Option<_>> =
+            async.TryFinally(computation(), compensation)
+
+        member inline _.Using(resource : 'T :> IDisposable, binder : 'T -> Task<Option<_>>) : Task<Option<_>> =
+            async.Using(resource, binder)
+
+        member _.While(guard : unit -> bool, computation : unit -> Task<Option<'U>>) : Task<Option<'U>> =
+            async {
+                let mutable fin, result = false, None
+
+                while not fin && guard () do
+                    match! computation () with
+                    | Some _ as o -> result <- o
+                    | None ->
+                        result <- None
+                        fin <- true
+
+                return result
+            }
+
+        member _.For(sequence : #seq<'T>, binder : 'T -> Task<Option<'U>>) : Task<Option<'U>> =
+            async {
+                use enumerator = sequence.GetEnumerator()
+                let mutable fin, result = false, None
+
+                while not fin && enumerator.MoveNext() do
+                    match! binder enumerator.Current with
+                    | Some _ as o -> result <- o
+                    | None ->
+                        result <- None
+                        fin <- true
+
+                return result
+            }
+
+        member inline _.Run(f : unit -> Task<'m>) = async.ReturnFrom (f())
+        
+        #endif
 
     let taskOption = TaskOptionBuilder()

--- a/src/Plough.ControlFlow/TaskOptionCE.fs
+++ b/src/Plough.ControlFlow/TaskOptionCE.fs
@@ -12,7 +12,7 @@ module TaskOptionCE =
 
         member inline _.ReturnFrom(taskResult : Task<Option<_>>) : Ply<Option<_>> = uply.ReturnFrom taskResult
 
-        #if FABLE_COMPILER
+        #if !FABLE_COMPILER
         member inline this.ReturnFrom(asyncResult : Async<Option<_>>) : Ply<Option<_>> =
             this.ReturnFrom(Async.StartAsTask asyncResult)
         #endif
@@ -29,7 +29,7 @@ module TaskOptionCE =
 
             uply.Bind(taskResult, binder')
 
-        #if FABLE_COMPILER
+        #if !FABLE_COMPILER
         member inline this.Bind(asyncResult : Async<Option<_>>, binder : 'T -> Ply<Option<_>>) : Ply<Option<_>> =
             this.Bind(Async.StartAsTask asyncResult, binder)
         #endif

--- a/src/Plough.ControlFlow/TaskOptionCE.fs
+++ b/src/Plough.ControlFlow/TaskOptionCE.fs
@@ -1,7 +1,6 @@
 namespace Plough.ControlFlow
 
 open System
-open System.Threading.Tasks
 open FSharp.Control.Tasks.Affine.Unsafe
 open FSharp.Control.Tasks.Affine
 open Ply
@@ -13,8 +12,10 @@ module TaskOptionCE =
 
         member inline _.ReturnFrom(taskResult : Task<Option<_>>) : Ply<Option<_>> = uply.ReturnFrom taskResult
 
+        #if FABLE_COMPILER
         member inline this.ReturnFrom(asyncResult : Async<Option<_>>) : Ply<Option<_>> =
             this.ReturnFrom(Async.StartAsTask asyncResult)
+        #endif
 
         member inline _.ReturnFrom(result : Option<_>) : Ply<Option<_>> = uply.Return result
 
@@ -28,8 +29,10 @@ module TaskOptionCE =
 
             uply.Bind(taskResult, binder')
 
+        #if FABLE_COMPILER
         member inline this.Bind(asyncResult : Async<Option<_>>, binder : 'T -> Ply<Option<_>>) : Ply<Option<_>> =
             this.Bind(Async.StartAsTask asyncResult, binder)
+        #endif
 
         member inline this.Bind(result : Option<_>, binder : 'T -> Ply<Option<_>>) : Ply<Option<_>> =
             let result = result |> Task.singleton


### PR DESCRIPTION
Tasks are currently not supported by Fable as they do not have direct equivalent in js. For our implementation, we've simply chosen to use replace them with Asyncs in the context of the fable compiler, and still support the extensions of the types.