### PR TITLE
Set Fable.Core  dependency range to >= 3.2.4

### DIFF
--- a/paket.template
+++ b/paket.template
@@ -13,7 +13,7 @@ copyright Demetrix 2021
 tags fsharp plough
 dependencies
   FSharp.Core >= 4.7.2
-  Fable.Core ~> 3.2.4
+  Fable.Core >= 3.2.4
   Ply ~> 0.3.1
 files
   src/Plough.ControlFlow/bin/Release ==> lib


### PR DESCRIPTION
Because of the use of Paket's `~>` operator, Fable.Core dependency is set to >= 3.2.4 && < 3.3.0, which is quite restrictive, because it means that a project referencing Plough.ControlFlow cannot update to Fable.Core 3.3. Given that Fable.Core doesn't usually have breaking changes (particularly not in a minor release) `>=` would be more appropriate as with FSharp.Core.

> There's a similar situation with Ply, but I haven't changed it because I wasn't sure if this was intended.