### PR TITLE
Include original exception as an inner exception in TaskEither.toTask.

### DIFF
--- a/src/Plough.ControlFlow/TaskEither.fs
+++ b/src/Plough.ControlFlow/TaskEither.fs
@@ -163,7 +163,14 @@ module TaskEither =
         |> Task.map (fun (r1, r2) -> Either.zip r1 r2)
                
     #if !FABLE_COMPILER
-    let toTask f = f |> foldResult id (fun error -> error.ToString() |> failwith) :> System.Threading.Tasks.Task
+    let toTask f =
+        f
+        |> foldResult id (fun error ->
+            match error with
+            | ExceptionFailure exn ->
+                raise <| System.Exception(exn.Message, exn)
+            | _ -> failwith <| error.ToString()
+        ) :> System.Threading.Tasks.Task
     
     /// Synchronously executes task and gets underlying Either<'result>. Not supported by Fable due to JS limitations.
     let runSynchronously (f: TaskEither<_>) = f.ConfigureAwait(false).GetAwaiter().GetResult()

--- a/test/Plough.ControlFlow.Tests/TaskEitherTests.fs
+++ b/test/Plough.ControlFlow.Tests/TaskEitherTests.fs
@@ -1,5 +1,6 @@
 module Plough.ControlFlow.Tests.TaskEitherTests
 
+open System
 open Plough.ControlFlow
 open Plough.ControlFlow.Tests.ErrorSpecs
 open Xunit
@@ -137,4 +138,16 @@ let ``two different bind types`` () = task {
         }
     let! _ = inner 3 "4.0" 
     ()
+}
+
+[<Fact>]
+let ``toTask includes inner exception`` () = task {
+    let innerException = Exception("test")
+    let! raised = Assert.ThrowsAsync<Exception>(fun () ->
+        taskEither {
+            do! Either.fail (ExceptionFailure innerException)
+        } |> TaskEither.toTask
+    )
+    Assert.NotNull raised.InnerException
+    Assert.Equal(innerException, raised.InnerException)
 }


### PR DESCRIPTION
This ensures that an exception already captured as an `ExceptionFailure` is properly represented as an inner exception when thrown by `TaskEither.toTask`, which will result in correct nested stack traces.