### PR TITLE
Replace TaskEither.onError with TaskEither.catch.

### DIFF
--- a/src/Plough.ControlFlow/TaskEither.fs
+++ b/src/Plough.ControlFlow/TaskEither.fs
@@ -153,6 +153,22 @@ module TaskEither =
     let teeError f (taskEither : TaskEither<'a>) : TaskEither<'a> =
         taskEither |> Task.map (Either.teeError f)
 
+    /// If the task-wrapped result is Error, executes the async function on the Error
+    /// value. Passes through the input value.
+    let teeErrorAsync (f : FailureMessage -> Task<unit>) (taskEither : TaskEither<'a>) : TaskEither<'a> =
+    #if !FABLE_COMPILER
+        task {
+    #else
+        async {
+    #endif
+            let! result = taskEither
+            match result with
+            | Ok _ -> ()
+            | Error x ->
+                do! f x
+            return result
+        }
+
     /// If the task-wrapped result is Error and the predicate returns true,
     /// executes the function on the Error value. Passes through the input value.
     let teeErrorIf (predicate : FailureMessage -> bool) (f : FailureMessage -> unit) (taskEither : TaskEither<'a>) : TaskEither<'a> =

--- a/src/Plough.ControlFlow/TaskEither.fs
+++ b/src/Plough.ControlFlow/TaskEither.fs
@@ -163,7 +163,20 @@ module TaskEither =
     let zip (x1 : TaskEither<'a>) (x2 : TaskEither<'b>) : TaskEither<'a * 'b> =
         Task.zip x1 x2
         |> Task.map (fun (r1, r2) -> Either.zip r1 r2)
-               
+
+    /// Executes a task, catching any exception and folding it into the error path.
+    let catch (f : unit -> TaskEither<'a>) : TaskEither<'a> =
+    #if !FABLE_COMPILER
+        task {
+    #else
+        async {
+    #endif
+            try
+                return! f()
+            with
+            | exn -> return! exn |> FailureMessage.ExceptionFailure |> returnError
+        }
+
     #if !FABLE_COMPILER
     let toTask f =
         f
@@ -177,34 +190,6 @@ module TaskEither =
     /// Synchronously executes task and gets underlying Either<'result>. Not supported by Fable due to JS limitations.
     let runSynchronously (f: TaskEither<_>) = f.ConfigureAwait(false).GetAwaiter().GetResult()
     
-    let inline onError (onError : FailureMessage -> TaskEither<'b>) (f : unit -> TaskEither<'b>) : TaskEither<'b> =
-        task {
-            let! result =    
-                task {
-                    try return! f()
-                    with
-                    | exn -> return! exn |> FailureMessage.ExceptionFailure |> returnError
-                }
-            
-            match result with
-            | Success _ | SuccessWithWarning _ -> return result
-            | Failure s -> return! onError s
-        }
-    
     #else
     type TaskEither<'a> = Async<Either<'a>>
-    let onError (onError : FailureMessage -> TaskEither<'b>) (f : unit -> TaskEither<'b>) : TaskEither<'b> =
-        async {
-            let! result =    
-                async {
-                    try return! f()
-                    with
-                    | exn -> return! exn |> FailureMessage.ExceptionFailure |> returnError
-                }
-            
-            match result with
-            | Success _ | SuccessWithWarning _ -> return result
-            | Failure s -> return! onError s
-        }
-    
     #endif


### PR DESCRIPTION
TaskEither.onError turns out to not be quite what we want.  It basically combines three actions into one function:

1. Execute a task and catch any exception as a `Error`.
2. Execute a side effect on the resulting `Error`.
3. Map the error into a new `TaskEither`, potentially either consuming the error or returning it.

I did a quick audit of the main codebase, and in every case we use `TaskEither.onError` the function in part 3 is "return the original error", and in one or two cases the side effect is "ignore", plus cases where the original error could be lost because the error handling function could itself fail.  Thus, I think we would be better served by the function I've replaced it with in this PR, `TaskEither.catch`, which is only responsible for 1.  All existing uses of `TaskEither.onError` would be replaced by `TaskEither.catch` followed by `TaskEither.teeError` to perform the side effect, ensuring we don't accidentally swallow the original error.  This refactoring also enables a slightly more legible codebase, because code that currently looks like this:

```F#
fun () ->
    taskEither {
        // ...some code that might raise an exception...
    }
|> TaskEither.onError (fun err ->
    taskEither {
       //  ...execute side effect on error...
        return! TaskEither.fail err
    }
```

becomes this:
```F#
TaskEither.catch (fun () ->
    taskEither {
        // ...some code that might raise an exception...
    })
|> TaskEither.teeError (fun err ->
    // ...work with the error here, returning nothing...
)
```

I like that `TaskEither.catch` is up-front, making it immediately clear in a top-to-bottom reading why there is a closure that accepts `()` being defined, and it also makes it clear via `teeError` that you are executing a side effect and not actually changing the resulting error.

If your side effect is itself an async function, though, it is necessary to use `TaskEither.teeErrorAsync`, which I have also implemented here.  I couldn't figure out an elegant way to define it using the existing `Either` functions, which I think might just be a result of it being tricky to adapt the sync world to the async world.